### PR TITLE
add code blocks to get extra enforcement actions

### DIFF
--- a/CA_Prisons2.ipynb
+++ b/CA_Prisons2.ipynb
@@ -1,168 +1,654 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!git clone https://github.com/edgi-govdata-archiving/ECHO_modules.git -b get_by_ee\n",
-    "!git clone https://github.com/shansen5/CA_Prisons.git\n",
-    "print( 'Done!' )"
-   ]
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.7"
+    },
+    "colab": {
+      "name": "CA_Prisons2.ipynb",
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%run ECHO_modules/DataSet.py\n",
-    "%run ECHO_modules/make_data_sets.py"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 1. Read the local spreadsheet with the carceral facilities"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "carc_data  = pd.read_csv( \"CA_Prisons/reformatted_fixed_GG_manual_coding_hifld_prisons_to_FRS.csv\", encoding='iso-8859-1',\n",
-    "                 dtype={\"Total_FRS_IDS\": \"Int64\"} )\n",
-    "registry_ids = carc_data['Total_FRS_IDS'].dropna().unique()\n",
-    "print( \"Number of records in CSV = {}, number of non-NA ids = {}\".format( len(carc_data), len(registry_ids)))\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2. Look up the facilities in ECHO_EXPORTER.  The records found will be written to ECHO_EXPORTER-CA_Carceral.csv."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If you have run this notebook before and have the ECHO_EXPORTER-CA_Carceral.csv file\n",
-    "already generated, you can use the following cell to read it directly and\n",
-    "save some time compared to the full database query.  If you don't have the\n",
-    "CSV file, skip to the next cell to get the data from the database."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "echo_data = pd.read_csv( \"ECHO_EXPORTER-CA_Carceral.csv\" )\n",
-    "echo_data.set_index( 'REGISTRY_ID', inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "id_list = []\n",
-    "for id in registry_ids:\n",
-    "    id_list.append( id )\n",
-    "    \n",
-    "ds = DataSet( name=\"exporter\", base_table=\"ECHO_EXPORTER\",\n",
-    "            table_name=\"ECHO_EXPORTER\", echo_type=None, idx_field=\"REGISTRY_ID\" )\n",
-    "echo_data = ds.get_data_by_ee_ids( id_list )\n",
-    "\n",
-    "echo_data.to_csv( \"ECHO_EXPORTER-CA_Carceral.csv\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3. Look up the facilities in the program data sets.  The records found will be written to CSV files for each data set."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false,
-    "tags": [
-     "outputPrepend"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "data_set_list = ['RCRA Violations', 'RCRA Inspections', 'RCRA Penalties',\n",
-    "                 'CAA Violations', 'CAA Inspections', 'CAA Penalties', \n",
-    "                 'Greenhouse Gas Emissions', 'Toxic Releases',\n",
-    "                 'CWA Violations', 'CWA Inspections', 'CWA Penalties',\n",
-    "                 'SDWA Violations', 'SDWA Serious Violators', 'SDWA Site Visits',\n",
-    "                 'SDWA Enforcements', ] \n",
-    "# You can run an individual data set, or just a few, by un-commenting and\n",
-    "# editing the following\n",
-    "# data_set_list = ['CWA Violations']\n",
-    "data_sets = make_data_sets( data_set_list )\n",
-    "last_flag = ''\n",
-    "pgm_ids = None\n",
-    "for pgm_name,ds in data_sets.items():\n",
-    "    print( pgm_name )\n",
-    "    if ( ds.echo_type == 'SDWA' ):\n",
-    "        echo_flag = 'SDWIS_FLAG'\n",
-    "    else:\n",
-    "        echo_flag = ds.echo_type + '_FLAG'\n",
-    "    # If the flag hasn't changed, the pgm_ids will still be the same.\n",
-    "    # Getting the pgm_ids from the echo_data's REGISTRY_ID takes a\n",
-    "    # long time, so we skip it if we can.\n",
-    "    if ( last_flag != echo_flag ):\n",
-    "        r_ids = echo_data[ echo_data[ echo_flag ] == 'Y' ].index\n",
-    "        pgm_ids = ds.get_pgm_ids( r_ids )\n",
-    "        last_flag = echo_flag\n",
-    "    program_data = ds.get_data_by_pgm_ids( pgm_ids )\n",
-    "    if ( program_data is not None):\n",
-    "        program_data.to_csv( pgm_name+'.csv' )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.7"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "cells": [
+    {
+      "cell_type": "code",
+      "metadata": {
+        "tags": [],
+        "id": "HIeMC4Tu3Qxi",
+        "outputId": "08537b9c-a3c7-4f61-8f66-631d2a35f3f2",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "!git clone https://github.com/edgi-govdata-archiving/ECHO_modules.git -b get_by_ee\n",
+        "!git clone https://github.com/shansen5/CA_Prisons.git\n",
+        "print( 'Done!' )"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Cloning into 'ECHO_modules'...\n",
+            "remote: Enumerating objects: 154, done.\u001b[K\n",
+            "remote: Counting objects: 100% (154/154), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (107/107), done.\u001b[K\n",
+            "remote: Total 154 (delta 80), reused 103 (delta 45), pack-reused 0\u001b[K\n",
+            "Receiving objects: 100% (154/154), 64.93 KiB | 5.41 MiB/s, done.\n",
+            "Resolving deltas: 100% (80/80), done.\n",
+            "Cloning into 'CA_Prisons'...\n",
+            "remote: Enumerating objects: 34, done.\u001b[K\n",
+            "remote: Counting objects: 100% (34/34), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (25/25), done.\u001b[K\n",
+            "remote: Total 34 (delta 17), reused 26 (delta 9), pack-reused 0\u001b[K\n",
+            "Unpacking objects: 100% (34/34), done.\n",
+            "Done!\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "r8eHF1iq3Qxo"
+      },
+      "source": [
+        "%run ECHO_modules/DataSet.py\n",
+        "%run ECHO_modules/make_data_sets.py"
+      ],
+      "execution_count": 2,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "xBJ1se-V3Qxo"
+      },
+      "source": [
+        "### 1. Read the local spreadsheet with the carceral facilities"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Tm7-NxVO3Qxp",
+        "outputId": "f1916464-2295-4687-a737-13033291ca25",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "carc_data  = pd.read_csv( \"CA_Prisons/reformatted_fixed_GG_manual_coding_hifld_prisons_to_FRS.csv\", encoding='iso-8859-1',\n",
+        "                 dtype={\"Total_FRS_IDS\": \"Int64\"} )\n",
+        "registry_ids = carc_data['Total_FRS_IDS'].dropna().unique()\n",
+        "print( \"Number of records in CSV = {}, number of non-NA ids = {}\".format( len(carc_data), len(registry_ids)))\n"
+      ],
+      "execution_count": 3,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Number of records in CSV = 14289, number of non-NA ids = 4707\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "7LPkR6lX3Qxp"
+      },
+      "source": [
+        "### 2. Look up the facilities in ECHO_EXPORTER.  The records found will be written to ECHO_EXPORTER-CA_Carceral.csv."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "NNJDApxj3Qxp"
+      },
+      "source": [
+        "If you have run this notebook before and have the ECHO_EXPORTER-CA_Carceral.csv file\n",
+        "already generated, you can use the following cell to read it directly and\n",
+        "save some time compared to the full database query.  If you don't have the\n",
+        "CSV file, skip to the next cell to get the data from the database."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "k-5xowFW3Qxq",
+        "outputId": "711d555a-75f0-4c6b-cac9-ac05e903dcc5",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 392
+        }
+      },
+      "source": [
+        "echo_data = pd.read_csv( \"CA_Prisons/rECHO_EXPORTER-CA_Carceral.csv\" )\n",
+        "echo_data.set_index( 'REGISTRY_ID', inplace=True)"
+      ],
+      "execution_count": 5,
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "FileNotFoundError",
+          "evalue": "ignored",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-5-6a5059020ed8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mecho_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_csv\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0;34m\"CA_Prisons/rECHO_EXPORTER-CA_Carceral.csv\"\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mecho_data\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mset_index\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0;34m'REGISTRY_ID'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minplace\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36mread_csv\u001b[0;34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, dialect, error_bad_lines, warn_bad_lines, delim_whitespace, low_memory, memory_map, float_precision)\u001b[0m\n\u001b[1;32m    686\u001b[0m     )\n\u001b[1;32m    687\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0m_read\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36m_read\u001b[0;34m(filepath_or_buffer, kwds)\u001b[0m\n\u001b[1;32m    452\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    453\u001b[0m     \u001b[0;31m# Create the parser.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 454\u001b[0;31m     \u001b[0mparser\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mTextFileReader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfp_or_buf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    455\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    456\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mchunksize\u001b[0m \u001b[0;32mor\u001b[0m \u001b[0miterator\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, f, engine, **kwds)\u001b[0m\n\u001b[1;32m    946\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moptions\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"has_index_names\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkwds\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"has_index_names\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    947\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 948\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_make_engine\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mengine\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    949\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    950\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36m_make_engine\u001b[0;34m(self, engine)\u001b[0m\n\u001b[1;32m   1178\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_make_engine\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mengine\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m\"c\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1179\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mengine\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"c\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1180\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_engine\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mCParserWrapper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moptions\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1181\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1182\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mengine\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"python\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, src, **kwds)\u001b[0m\n\u001b[1;32m   2008\u001b[0m         \u001b[0mkwds\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"usecols\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0musecols\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2009\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 2010\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_reader\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mparsers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTextReader\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msrc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   2011\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munnamed_cols\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_reader\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0munnamed_cols\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   2012\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32mpandas/_libs/parsers.pyx\u001b[0m in \u001b[0;36mpandas._libs.parsers.TextReader.__cinit__\u001b[0;34m()\u001b[0m\n",
+            "\u001b[0;32mpandas/_libs/parsers.pyx\u001b[0m in \u001b[0;36mpandas._libs.parsers.TextReader._setup_parser_source\u001b[0;34m()\u001b[0m\n",
+            "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'CA_Prisons/rECHO_EXPORTER-CA_Carceral.csv'"
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": false,
+        "id": "tkzvq-jM3Qxq",
+        "outputId": "84d017c2-f242-4a9a-ee13-e61b8502386c",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        }
+      },
+      "source": [
+        "id_list = []\n",
+        "for id in registry_ids:\n",
+        "    id_list.append( id )\n",
+        "    \n",
+        "ds = DataSet( name=\"exporter\", base_table=\"ECHO_EXPORTER\",\n",
+        "            table_name=\"ECHO_EXPORTER\", echo_type=None, idx_field=\"REGISTRY_ID\" )\n",
+        "echo_data = ds.get_data_by_ee_ids( id_list )\n",
+        "\n",
+        "echo_data.to_csv( \"ECHO_EXPORTER-CA_Carceral.csv\")"
+      ],
+      "execution_count": 6,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "...\n",
+            "4707 ids were searched for\n",
+            "2402 program records were found\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "L1hmZNY93Qxq"
+      },
+      "source": [
+        "### 3. Look up the facilities in the program data sets.  The records found will be written to CSV files for each data set."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "scrolled": false,
+        "tags": [
+          "outputPrepend"
+        ],
+        "id": "FXl-hWCq3Qxq",
+        "outputId": "a2766c08-4b4f-401d-f84c-85bb0d85c757",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 392
+        }
+      },
+      "source": [
+        "data_set_list = ['RCRA Violations', 'RCRA Inspections', 'RCRA Penalties',\n",
+        "                 'CAA Violations', 'CAA Inspections', 'CAA Penalties', \n",
+        "                 'Greenhouse Gas Emissions', 'Toxic Releases',\n",
+        "                 'CWA Violations', 'CWA Inspections', 'CWA Penalties',\n",
+        "                 'SDWA Violations', 'SDWA Serious Violators', 'SDWA Site Visits',\n",
+        "                 'SDWA Enforcements', ] \n",
+        "# You can run an individual data set, or just a few, by un-commenting and\n",
+        "# editing the following\n",
+        "# data_set_list = ['CWA Violations']\n",
+        "data_sets = make_data_sets( data_set_list )\n",
+        "last_flag = ''\n",
+        "pgm_ids = None\n",
+        "for pgm_name,ds in data_sets.items():\n",
+        "    print( pgm_name )\n",
+        "    if ( ds.echo_type == 'SDWA' ):\n",
+        "        echo_flag = 'SDWIS_FLAG'\n",
+        "    else:\n",
+        "        echo_flag = ds.echo_type + '_FLAG'\n",
+        "    # If the flag hasn't changed, the pgm_ids will still be the same.\n",
+        "    # Getting the pgm_ids from the echo_data's REGISTRY_ID takes a\n",
+        "    # long time, so we skip it if we can.\n",
+        "    if ( last_flag != echo_flag ):\n",
+        "        r_ids = echo_data[ echo_data[ echo_flag ] == 'Y' ].index\n",
+        "        pgm_ids = ds.get_pgm_ids( r_ids )\n",
+        "        last_flag = echo_flag\n",
+        "    program_data = ds.get_data_by_pgm_ids( pgm_ids )\n",
+        "    if ( program_data is not None):\n",
+        "        program_data.to_csv( pgm_name+'.csv' )"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "RCRA Violations\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "error",
+          "ename": "KeyboardInterrupt",
+          "evalue": "ignored",
+          "traceback": [
+            "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+            "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+            "\u001b[0;32m<ipython-input-7-24be0fbf8f4c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m     22\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m \u001b[0mlast_flag\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mecho_flag\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m         \u001b[0mr_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mecho_data\u001b[0m\u001b[0;34m[\u001b[0m \u001b[0mecho_data\u001b[0m\u001b[0;34m[\u001b[0m \u001b[0mecho_flag\u001b[0m \u001b[0;34m]\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m'Y'\u001b[0m \u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mindex\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m         \u001b[0mpgm_ids\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_pgm_ids\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0mr_ids\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m         \u001b[0mlast_flag\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mecho_flag\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m     \u001b[0mprogram_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mds\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_data_by_pgm_ids\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0mpgm_ids\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/content/ECHO_modules/DataSet.py\u001b[0m in \u001b[0;36mget_pgm_ids\u001b[0;34m(self, ee_ids, int_flag)\u001b[0m\n\u001b[1;32m    195\u001b[0m                     \u001b[0mx_sql\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m'select \"PGM_ID\" from \"EXP_PGM\" where \"REGISTRY_ID\" in ('\u001b[0m\u001b[0;31m \u001b[0m\u001b[0;31m\\\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    196\u001b[0m                                     \u001b[0;34m+\u001b[0m \u001b[0mid_string\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;34m')'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 197\u001b[0;31m                     \u001b[0mthis_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_data\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0mx_sql\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    198\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merrors\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mEmptyDataError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    199\u001b[0m                     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m \u001b[0;34m\"...\"\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/content/ECHO_modules/DataSet.py\u001b[0m in \u001b[0;36mget_data\u001b[0;34m(sql, index_field)\u001b[0m\n\u001b[1;32m     17\u001b[0m                  dtype={\"REGISTRY_ID\": \"Int64\"})\n\u001b[1;32m     18\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m         \u001b[0mds\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpd\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_csv\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdata_location\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mencoding\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'iso-8859-1'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     20\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m \u001b[0mindex_field\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     21\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36mread_csv\u001b[0;34m(filepath_or_buffer, sep, delimiter, header, names, index_col, usecols, squeeze, prefix, mangle_dupe_cols, dtype, engine, converters, true_values, false_values, skipinitialspace, skiprows, skipfooter, nrows, na_values, keep_default_na, na_filter, verbose, skip_blank_lines, parse_dates, infer_datetime_format, keep_date_col, date_parser, dayfirst, cache_dates, iterator, chunksize, compression, thousands, decimal, lineterminator, quotechar, quoting, doublequote, escapechar, comment, encoding, dialect, error_bad_lines, warn_bad_lines, delim_whitespace, low_memory, memory_map, float_precision)\u001b[0m\n\u001b[1;32m    686\u001b[0m     )\n\u001b[1;32m    687\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 688\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0m_read\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkwds\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    689\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    690\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/parsers.py\u001b[0m in \u001b[0;36m_read\u001b[0;34m(filepath_or_buffer, kwds)\u001b[0m\n\u001b[1;32m    435\u001b[0m     \u001b[0;31m# See https://github.com/python/mypy/issues/1297\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    436\u001b[0m     fp_or_buf, _, compression, should_close = get_filepath_or_buffer(\n\u001b[0;32m--> 437\u001b[0;31m         \u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mencoding\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcompression\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    438\u001b[0m     )\n\u001b[1;32m    439\u001b[0m     \u001b[0mkwds\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"compression\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcompression\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/common.py\u001b[0m in \u001b[0;36mget_filepath_or_buffer\u001b[0;34m(filepath_or_buffer, encoding, compression, mode, storage_options)\u001b[0m\n\u001b[1;32m    181\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mis_url\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    182\u001b[0m         \u001b[0;31m# TODO: fsspec can also handle HTTP via requests, but leaving this unchanged\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 183\u001b[0;31m         \u001b[0mreq\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0murlopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath_or_buffer\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    184\u001b[0m         \u001b[0mcontent_encoding\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheaders\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"Content-Encoding\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    185\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mcontent_encoding\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"gzip\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/local/lib/python3.6/dist-packages/pandas/io/common.py\u001b[0m in \u001b[0;36murlopen\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    135\u001b[0m     \u001b[0;32mimport\u001b[0m \u001b[0murllib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrequest\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    136\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 137\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0murllib\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrequest\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0murlopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    138\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    139\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36murlopen\u001b[0;34m(url, data, timeout, cafile, capath, cadefault, context)\u001b[0m\n\u001b[1;32m    221\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0mopener\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_opener\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 223\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopener\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    224\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    225\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0minstall_opener\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mopener\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(self, fullurl, data, timeout)\u001b[0m\n\u001b[1;32m    524\u001b[0m             \u001b[0mreq\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mmeth\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreq\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    525\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 526\u001b[0;31m         \u001b[0mresponse\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mreq\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    527\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    528\u001b[0m         \u001b[0;31m# post-process response\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36m_open\u001b[0;34m(self, req, data)\u001b[0m\n\u001b[1;32m    542\u001b[0m         \u001b[0mprotocol\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtype\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    543\u001b[0m         result = self._call_chain(self.handle_open, protocol, protocol +\n\u001b[0;32m--> 544\u001b[0;31m                                   '_open', req)\n\u001b[0m\u001b[1;32m    545\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    546\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36m_call_chain\u001b[0;34m(self, chain, kind, meth_name, *args)\u001b[0m\n\u001b[1;32m    502\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mhandler\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mhandlers\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    503\u001b[0m             \u001b[0mfunc\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgetattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhandler\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmeth_name\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 504\u001b[0;31m             \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    505\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    506\u001b[0m                 \u001b[0;32mreturn\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36mhttp_open\u001b[0;34m(self, req)\u001b[0m\n\u001b[1;32m   1351\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1352\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mhttp_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1353\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdo_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mhttp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclient\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mHTTPConnection\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreq\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1354\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1355\u001b[0m     \u001b[0mhttp_request\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mAbstractHTTPHandler\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdo_request_\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/urllib/request.py\u001b[0m in \u001b[0;36mdo_open\u001b[0;34m(self, http_class, req, **http_conn_args)\u001b[0m\n\u001b[1;32m   1326\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mOSError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0merr\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0;31m# timeout error\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1327\u001b[0m                 \u001b[0;32mraise\u001b[0m \u001b[0mURLError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0merr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1328\u001b[0;31m             \u001b[0mr\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mh\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mgetresponse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1329\u001b[0m         \u001b[0;32mexcept\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1330\u001b[0m             \u001b[0mh\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/http/client.py\u001b[0m in \u001b[0;36mgetresponse\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1371\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1372\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1373\u001b[0;31m                 \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbegin\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1374\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mConnectionError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1375\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/http/client.py\u001b[0m in \u001b[0;36mbegin\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    309\u001b[0m         \u001b[0;31m# read until we get a non-100 response\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    310\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 311\u001b[0;31m             \u001b[0mversion\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatus\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreason\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_read_status\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    312\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0mstatus\u001b[0m \u001b[0;34m!=\u001b[0m \u001b[0mCONTINUE\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    313\u001b[0m                 \u001b[0;32mbreak\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/http/client.py\u001b[0m in \u001b[0;36m_read_status\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    270\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    271\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_read_status\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 272\u001b[0;31m         \u001b[0mline\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadline\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0m_MAXLINE\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"iso-8859-1\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    273\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mlen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m>\u001b[0m \u001b[0m_MAXLINE\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    274\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mLineTooLong\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"status line\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;32m/usr/lib/python3.6/socket.py\u001b[0m in \u001b[0;36mreadinto\u001b[0;34m(self, b)\u001b[0m\n\u001b[1;32m    584\u001b[0m         \u001b[0;32mwhile\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    585\u001b[0m             \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 586\u001b[0;31m                 \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sock\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrecv_into\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mb\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    587\u001b[0m             \u001b[0;32mexcept\u001b[0m \u001b[0mtimeout\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    588\u001b[0m                 \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_timeout_occurred\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+            "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+          ]
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "lpLAttjz6ebS"
+      },
+      "source": [
+        "Parse out REGISTRY_IDs in order to query ICIS federal enforcement and compliance table"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "1cVLMEp35hQJ",
+        "outputId": "3b3e6c66-bbb7-4536-bf55-0d46a2228c44",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 35
+        }
+      },
+      "source": [
+        "ids = \"\"\n",
+        "for id in id_list[1:10]: # test on just 20 REGISTRY_IDs\n",
+        "    ids+=\"'\"+str(id)+\"',\"\n",
+        "ids=ids[:-1] #remove trailing comma\n",
+        "ids=ids+\",'110013272680'\" #Texas Department of Corrections facility (for testing purposes)\n",
+        "ids"
+      ],
+      "execution_count": 46,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "application/vnd.google.colaboratory.intrinsic+json": {
+              "type": "string"
+            },
+            "text/plain": [
+              "\"'110011628756','110012969083','110064064382','110045674267','110043979086','110010111887','110050978527','110060265591','110045700924','110013272680'\""
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 46
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "eUgu4UOoAe5-"
+      },
+      "source": [
+        "Get case numbers based on REGISTRY_IDs"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WR7cdYj93Qxr",
+        "outputId": "7ecf66c2-1b79-4ee7-d539-fef2c070a7b0",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 165
+        }
+      },
+      "source": [
+        "facilities = None\n",
+        "try:\n",
+        "  #sql = 'select * from \"CASE_FACILITIES\" where \"REGISTRY_ID\" = \\'110013272680\\'' #Texas Department of Corrections facility (for testing purposes)\n",
+        "  sql = 'select * from \"CASE_FACILITIES\" where \"REGISTRY_ID\" in ('+ids+')'\n",
+        "  url= 'http://portal.gss.stonybrook.edu/echoepa/index.php?query=' # Old server: 'http://apps.tlt.stonybrook.edu/echoepa/index2.php?query='\n",
+        "  data_location=url+urllib.parse.quote_plus(sql) + '&pg'\n",
+        "  print(sql) # For debugging\n",
+        "  print(data_location)\n",
+        "  facilities = pd.read_csv(data_location)\n",
+        "except pd.errors.EmptyDataError:\n",
+        "  print(\"No facilities match!\")\n",
+        "facilities"
+      ],
+      "execution_count": 51,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "select * from \"CASE_FACILITIES\" where \"REGISTRY_ID\" in ('110011628756','110012969083','110064064382','110045674267','110043979086','110010111887','110050978527','110060265591','110045700924','110013272680')\n",
+            "http://portal.gss.stonybrook.edu/echoepa/index.php?query=select+%2A+from+%22CASE_FACILITIES%22+where+%22REGISTRY_ID%22+in+%28%27110011628756%27%2C%27110012969083%27%2C%27110064064382%27%2C%27110045674267%27%2C%27110043979086%27%2C%27110010111887%27%2C%27110050978527%27%2C%27110060265591%27%2C%27110045700924%27%2C%27110013272680%27%29&pg\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>ACTIVITY_ID</th>\n",
+              "      <th>CASE_NUMBER</th>\n",
+              "      <th>REGISTRY_ID</th>\n",
+              "      <th>FACILITY_NAME</th>\n",
+              "      <th>LOCATION_ADDRESS</th>\n",
+              "      <th>CITY</th>\n",
+              "      <th>STATE_CODE</th>\n",
+              "      <th>ZIP</th>\n",
+              "      <th>PRIMARY_SIC_CODE</th>\n",
+              "      <th>PRIMARY_NAICS_CODE</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>3600738616</td>\n",
+              "      <td>06-2016-1212</td>\n",
+              "      <td>110013272680</td>\n",
+              "      <td>TDCJ W PACK UNIT</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>TX</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>2600045351</td>\n",
+              "      <td>06-2011-1355</td>\n",
+              "      <td>110013272680</td>\n",
+              "      <td>TDCJ W PACK UNIT</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>TX</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   ACTIVITY_ID   CASE_NUMBER  ...  PRIMARY_SIC_CODE PRIMARY_NAICS_CODE\n",
+              "0   3600738616  06-2016-1212  ...               NaN                NaN\n",
+              "1   2600045351  06-2011-1355  ...               NaN                NaN\n",
+              "\n",
+              "[2 rows x 10 columns]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 51
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f2Ap1tQoAiwP"
+      },
+      "source": [
+        "Use case numbers to get enforcement action details"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "NpukXjs65OSg",
+        "outputId": "35186002-5128-4408-a1cb-7fbdd07ef3d1",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 250
+        }
+      },
+      "source": [
+        "#separate out case numbers in order to query the CASE_ENFORCEMENTS table\n",
+        "cases_list = list(facilities[\"CASE_NUMBER\"].unique())\n",
+        "cases = \"\"\n",
+        "for case in cases_list:\n",
+        "  cases+=\"'\"+case+\"',\"\n",
+        "cases=cases[:-1] #remove trailing comma\n",
+        "actions = None\n",
+        "\n",
+        "#query the CASE_ENFORCEMENTS table\n",
+        "try:\n",
+        "  sql = 'select * from \"CASE_ENFORCEMENTS\" where \"CASE_NUMBER\" in ('+cases+')'\n",
+        "  url= 'http://portal.gss.stonybrook.edu/echoepa/index.php?query=' # Old server: 'http://apps.tlt.stonybrook.edu/echoepa/index2.php?query='\n",
+        "  data_location=url+urllib.parse.quote_plus(sql) + '&pg'\n",
+        "  print(sql) # For debugging\n",
+        "  print(data_location)\n",
+        "  actions = pd.read_csv(data_location)\n",
+        "except pd.errors.EmptyDataError:\n",
+        "  print(\"No actions found!\")\n",
+        "actions\n",
+        "\n",
+        "actions.to_csv('additional_enforcements.csv' )"
+      ],
+      "execution_count": 59,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "select * from \"CASE_ENFORCEMENTS\" where \"CASE_NUMBER\" in ('06-2016-1212','06-2011-1355')\n",
+            "http://portal.gss.stonybrook.edu/echoepa/index.php?query=select+%2A+from+%22CASE_ENFORCEMENTS%22+where+%22CASE_NUMBER%22+in+%28%2706-2016-1212%27%2C%2706-2011-1355%27%29&pg\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>ACTIVITY_ID</th>\n",
+              "      <th>ACTIVITY_NAME</th>\n",
+              "      <th>STATE_CODE</th>\n",
+              "      <th>REGION_CODE</th>\n",
+              "      <th>FISCAL_YEAR</th>\n",
+              "      <th>CASE_NUMBER</th>\n",
+              "      <th>CASE_NAME</th>\n",
+              "      <th>ACTIVITY_TYPE_CODE</th>\n",
+              "      <th>ACTIVITY_TYPE_DESC</th>\n",
+              "      <th>ACTIVITY_STATUS_CODE</th>\n",
+              "      <th>ACTIVITY_STATUS_DESC</th>\n",
+              "      <th>ACTIVITY_STATUS_DATE</th>\n",
+              "      <th>LEAD</th>\n",
+              "      <th>CASE_STATUS_DATE</th>\n",
+              "      <th>DOJ_DOCKET_NMBR</th>\n",
+              "      <th>ENF_OUTCOME_CODE</th>\n",
+              "      <th>ENF_OUTCOME_DESC</th>\n",
+              "      <th>TOTAL_PENALTY_ASSESSED_AMT</th>\n",
+              "      <th>TOTAL_COST_RECOVERY_AMT</th>\n",
+              "      <th>TOTAL_COMP_ACTION_AMT</th>\n",
+              "      <th>HQ_DIVISION</th>\n",
+              "      <th>BRANCH</th>\n",
+              "      <th>VOLUNTARY_SELF_DISCLOSURE_FLAG</th>\n",
+              "      <th>MULTIMEDIA_FLAG</th>\n",
+              "      <th>ENF_SUMMARY_TEXT</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>2600045351</td>\n",
+              "      <td>TDCJW Pack Unit</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2011</td>\n",
+              "      <td>06-2011-1355</td>\n",
+              "      <td>TDCJW Pack Unit</td>\n",
+              "      <td>AFR</td>\n",
+              "      <td>Administrative - Formal</td>\n",
+              "      <td>CSU</td>\n",
+              "      <td>Closed Superseded</td>\n",
+              "      <td>05/26/2016</td>\n",
+              "      <td>EPA</td>\n",
+              "      <td>05/26/2016</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>ESU</td>\n",
+              "      <td>Superseded by Another Enforcement Action</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>6EN-W</td>\n",
+              "      <td>N</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>Administrative order issued for non compliance...</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>3600738616</td>\n",
+              "      <td>Texas Department of Criminal Justice</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>6</td>\n",
+              "      <td>2016</td>\n",
+              "      <td>06-2016-1212</td>\n",
+              "      <td>Texas Department of Criminal Justice</td>\n",
+              "      <td>AFR</td>\n",
+              "      <td>Administrative - Formal</td>\n",
+              "      <td>CLS</td>\n",
+              "      <td>Closed</td>\n",
+              "      <td>10/25/2017</td>\n",
+              "      <td>EPA</td>\n",
+              "      <td>10/25/2017</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>ECN</td>\n",
+              "      <td>Final Order No Penalty</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>6EN-W</td>\n",
+              "      <td>N</td>\n",
+              "      <td>NaN</td>\n",
+              "      <td>On May 26, 2016, EPA Region 6 issued an Admini...</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   ACTIVITY_ID  ...                                   ENF_SUMMARY_TEXT\n",
+              "0   2600045351  ...  Administrative order issued for non compliance...\n",
+              "1   3600738616  ...  On May 26, 2016, EPA Region 6 issued an Admini...\n",
+              "\n",
+              "[2 rows x 25 columns]"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 59
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ZvAMoB9oAqQn"
+      },
+      "source": [
+        "\"\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
 }


### PR DESCRIPTION
I added some code blocks to grab "extra" enforcement actions NOT listed in these default tables:

```
data_set_list = ['RCRA Violations', 'RCRA Inspections', 'RCRA Penalties',
                 'CAA Violations', 'CAA Inspections', 'CAA Penalties', 
                 'Greenhouse Gas Emissions', 'Toxic Releases',
                 'CWA Violations', 'CWA Inspections', 'CWA Penalties',
                 'SDWA Violations', 'SDWA Serious Violators', 'SDWA Site Visits',
                 'SDWA Enforcements', ] 
```
This is in response to some data "errors" @shapironick noted here https://github.com/edgi-govdata-archiving/EEW_Planning/issues/96#issuecomment-772834279

The code blocks are very rough - they involve sorting out IDs and then querying the database - but hopefully you could take it from here!